### PR TITLE
Flex driver should handle environments without syslog

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,10 @@ var Version string
 
 func main() {
 
+	if len(os.Args) == 1 {
+		fmt.Errorf("Invalid number of parameters")
+		os.Exit(1)
+	}
 	apiCall := os.Args[1]
 
 	// Print version and exit.
@@ -41,11 +45,17 @@ func main() {
 		os.Exit(0)
 	}
 
-	sysLog, err := syslog.New(syslog.LOG_INFO, "Linstor FlexVolume")
-	if err != nil {
-		log.Fatal(err)
+	syslogOut, err := syslog.New(syslog.LOG_INFO, "Linstor FlexVolume")
+	if err == nil {
+		log.SetOutput(syslogOut)
+	} else {
+		fileOut, err := os.OpenFile("/tmp/linstor_flex", os.O_RDWR | os.O_CREATE | os.O_APPEND, 0666)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer fileOut.Close()
+		log.SetOutput(fileOut)
 	}
-	log.SetOutput(sysLog)
 
 	log.Printf("called with %s: %s", apiCall, strings.Join(os.Args[2:], ", "))
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log"
 	"log/syslog"
+	"os"
 	"strconv"
 
 	linstor "github.com/LINBIT/golinstor"
@@ -143,12 +144,17 @@ func parseOptions(s string) (options, error) {
 var logOutput io.Writer
 
 func init() {
-	out, err := syslog.New(syslog.LOG_INFO, "Linstor FlexVolume")
-	if err != nil {
-		log.Fatal(err)
+	syslogOut, err := syslog.New(syslog.LOG_INFO, "Linstor FlexVolume")
+	if err == nil {
+		logOutput = syslogOut
+	} else {
+		fileOut, errF := os.OpenFile("/tmp/linstor_flex", os.O_RDWR | os.O_CREATE | os.O_APPEND, 0666)
+		if errF != nil {
+			log.Fatal(errF)
+		}
+		defer fileOut.Close()
+		logOutput = fileOut
 	}
-
-	logOutput = out
 }
 
 type FlexVolumeApi struct{}


### PR DESCRIPTION
OCP controller manager containers haven't got syslog installed.
To handle that situation and unlock this driver to work in such
environment, we need to redirect logs to another destination.

We were experimenting with using stdout/stderr to achieve that
goal but, OCP is parsing whole output(i.e. incl. both stdout and
stderr). To don't loose logs we've decided to use logging to file.